### PR TITLE
Vcpkg as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "vcpkg"]
+	path = vcpkg
+	url = https://github.com/Microsoft/vcpkg.git

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
 - Install "Desktop Development with C++" in the visual studio installer (for cmake) if you haven't already
 - It will ask which cmake thing to use, use <project_root>/code/CMakeLists.txt
 - Everything should build for you wooooo lmk if there's an issue
+1. To run, use the green button dropdown to find `cpsc585-client.exe` or someth it'll work I think
 
 - see the IDE integration section here:
   - https://vcpkg.io/en/docs/users/buildsystems/cmake-integration.html

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 ## getting started
 
-to get started on contributing to this project, you'll need to install `vcpkg`, a c++ package manager. you will likely also want to config your editor of choice to work with CMake, or you can use CMake at the command line (commands are in )
-
-1. install `CMake` (not required if using Visual Studio)
-2. from the root of the project, run `./init.sh` on mac/linux, or `.\init.ps1` on windows - this will install vcpkg and the project dependencies, then build the project. In fact, if you want to
-build the project entirely using this script it'll work (I think)!
+1. install `CMake` if not on windows, or "Desktop Development with C++" in the visual studio installer in windows (it provides cmake)
+2. from the root of the project, run `./init.sh` on mac/linux, or `.\init.ps1` on windows - this will install and bootstrap vcpkg on windows and on mac/linux it builds the project as well
 3. setup your IDE to run with the project. (if not using IDE, I'd recommend just using the commands from the `init` scripts manually)
+- Install "Desktop Development with C++" in the visual studio installer (for cmake) if you haven't already
+- It will ask which cmake thing to use, use <project_root>/code/CMakeLists.txt
+- Everything should build for you wooooo lmk if there's an issue
 
 - see the IDE integration section here:
   - https://vcpkg.io/en/docs/users/buildsystems/cmake-integration.html

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # cpsc585
 
-## getting started
+## getting started (windows)
 
-1. install `CMake` if not on windows, or "Desktop Development with C++" in the visual studio installer in windows (it provides cmake)
-2. from the root of the project, run `./init.sh` on mac/linux, or `.\init.ps1` on windows - this will install and bootstrap vcpkg on windows and on mac/linux it builds the project as well
-3. setup your IDE to run with the project. (if not using IDE, I'd recommend just using the commands from the `init` scripts manually)
+1. install "Desktop Development with C++" in the visual studio installer (it provides `cmake`)
+1. open powershell and cd to the root directory of the project
+1. run the command `Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process` (still in powershell in the root dir)
+1. run the command `.\init.ps1` in powershell (still in powershell in the root dir)
+1. setup your IDE to run with the project. (if not using IDE, I'd recommend just using the commands from the `init` scripts manually)
 - Install "Desktop Development with C++" in the visual studio installer (for cmake) if you haven't already
 - It will ask which cmake thing to use, use <project_root>/code/CMakeLists.txt
 - Everything should build for you wooooo lmk if there's an issue
 
 - see the IDE integration section here:
   - https://vcpkg.io/en/docs/users/buildsystems/cmake-integration.html
+  
+NOTE: dylan i think you and i are fine without instructions
 
 ## project organization
 

--- a/README.md
+++ b/README.md
@@ -5,18 +5,9 @@
 to get started on contributing to this project, you'll need to install `vcpkg`, a c++ package manager. you will likely also want to config your editor of choice to work with CMake, or you can use CMake at the command line (commands are in )
 
 1. install `CMake` (not required if using Visual Studio)
-2. install `vcpkg` by following the instructions here: https://vcpkg.io/en/getting-started.html
-3. set the CMAKE_TOOLCHAIN_FILE location to your vcpkg toolchain file:
-
-- if you're using the scripts I've provided:
-  - open up the `code/init.ps1` or `code/init.sh` (based on architecture)
-  - modify the first line, changing `-DCMAKE_TOOLCHAIN_FILE=[vcpkg base]/scripts/buildsystems/vcpkg.cmake` by subbing in the folder where you installed vcpkg into `[vcpkg base]`
-    - for example, mine ended up as: `-DCMAKE_TOOLCHAIN_FILE=R:/newrepos/vcpkg/scripts/buildsystems/vcpkg.cmake"`
-  - run the script:
-    - `cd code`
-    - `./init.ps1`
-
-4. setup your IDE to run with the project. (if not using IDE, I'd recommend just using the commands from the `init` scripts manually)
+2. from the root of the project, run `./init.sh` on mac/linux, or `.\init.ps1` on windows - this will install vcpkg and the project dependencies, then build the project. In fact, if you want to
+build the project entirely using this script it'll work (I think)!
+3. setup your IDE to run with the project. (if not using IDE, I'd recommend just using the commands from the `init` scripts manually)
 
 - see the IDE integration section here:
   - https://vcpkg.io/en/docs/users/buildsystems/cmake-integration.html

--- a/code/.gitignore
+++ b/code/.gitignore
@@ -8,3 +8,6 @@ compile_commands.json
 cmake_install.cmake
 CTestTestfile.cmake
 Makefile*
+
+# XXX: should we actually vc this? i don't think so but idk
+**/CMakeSettings.json

--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.16)
+set(CMAKE_TOOLCHAIN_FILE "${CMAKE_CURRENT_SOURCE_DIR}/../vcpkg/scripts/buildsystems/vcpkg.cmake"
+  CACHE STRING "Vcpkg toolchain file")
 project(cpsc585 VERSION 0.1.0)
 
 set(CMAKE_CXX_STANDARD 17)

--- a/code/init.ps1
+++ b/code/init.ps1
@@ -1,4 +1,6 @@
-cmake -B ..\build\ -S . "-DCMAKE_TOOLCHAIN_FILE=[vcpkg base]/scripts/buildsystems/vcpkg.cmake"
+git submodule update --init --recursive # XXX: IDK if I can do this in powershell
+..\vcpkg\bootstrap-vcpkg.bat
+cmake -B ..\build\ -S .
 cmake --build ..\build\
 
 # example command to run built project from command line:

--- a/code/init.sh
+++ b/code/init.sh
@@ -1,4 +1,6 @@
-cmake -B ../build/ -S . "-DCMAKE_TOOLCHAIN_FILE=[vcpkg base]/scripts/buildsystems/vcpkg.cmake"
+git submodule update --init --recursive
+../vcpkg/bootstrap-vcpkg.sh
+cmake -B ../build/ -S .
 cmake --build ../build/
 
 # example command to run built project from command line:

--- a/init.ps1
+++ b/init.ps1
@@ -1,7 +1,7 @@
 git submodule update --init --recursive # XXX: IDK if I can do this in powershell
-..\vcpkg\bootstrap-vcpkg.bat
-cmake -B ..\build\ -S .
-cmake --build ..\build\
+.\vcpkg\bootstrap-vcpkg.bat
+cmake -B build\ -S code\
+cmake --build build\
 
 # example command to run built project from command line:
-# ../build/client/Debug/cpsc585_client.exe
+# ./build/client/Debug/cpsc585_client.exe

--- a/init.ps1
+++ b/init.ps1
@@ -1,7 +1,5 @@
 git submodule update --init --recursive # XXX: IDK if I can do this in powershell
 .\vcpkg\bootstrap-vcpkg.bat
-cmake -B build\ -S code\
-cmake --build build\
 
 # example command to run built project from command line:
 # ./build/client/Debug/cpsc585_client.exe

--- a/init.sh
+++ b/init.sh
@@ -1,7 +1,7 @@
 git submodule update --init --recursive
-../vcpkg/bootstrap-vcpkg.sh
-cmake -B ../build/ -S .
-cmake --build ../build/
+./vcpkg/bootstrap-vcpkg.sh
+cmake -B build/ -S code/
+cmake --build build/
 
 # example command to run built project from command line:
 # ../build/client/Debug/cpsc585_client.exe


### PR DESCRIPTION
initialize the project quickly and easily:
- no installing vcpkg yourself
- no setting variables in scripts (git worktree remains clean yaaayyyy)
- run 1 script to install vcpkg, dependencies ~, and then to build project~, build with visual studio + cmake