### PR TITLE
GLFW -> SDL2

### DIFF
--- a/code/CMakeLists.txt
+++ b/code/CMakeLists.txt
@@ -14,7 +14,6 @@ find_package(GTest CONFIG REQUIRED)
 find_package(glm CONFIG REQUIRED)
 find_package(glew REQUIRED)
 find_package(assimp CONFIG REQUIRED)
-find_package(glfw3 CONFIG REQUIRED)
 find_package(tomlplusplus CONFIG REQUIRED)
 find_package(imgui CONFIG REQUIRED)
 

--- a/code/assets/shaders/test.frag
+++ b/code/assets/shaders/test.frag
@@ -1,4 +1,4 @@
-#version 330 core
+#version 460 core
 out vec4 color;
 
 in vec3 C;

--- a/code/assets/shaders/test.vert
+++ b/code/assets/shaders/test.vert
@@ -1,4 +1,4 @@
-#version 330 core
+#version 460 core
 layout (location = 0) in vec3 pos;
 layout (location = 1) in vec3 col;
 

--- a/code/client/CMakeLists.txt
+++ b/code/client/CMakeLists.txt
@@ -13,7 +13,6 @@ target_link_libraries(${BINARY} PRIVATE ${CMAKE_PROJECT_NAME}_lib
   glm::glm
   GLEW::GLEW
   assimp::assimp
-  glfw
   vivid
   fmt
   tomlplusplus::tomlplusplus

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -4,6 +4,13 @@
 
 #include <iostream>
 
+void sdl_error_handler(int sdl_return) {
+	if (!sdl_return) return;
+	Log::error("SDL error: ", SDL_GetError());
+	SDL_Quit();
+	exit(1);
+}
+
 
 // ---------------------------
 // static function definitions
@@ -51,19 +58,32 @@ Window::Window(
 	, callbacks(callbacks)
 {
 	// specify OpenGL version
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-	glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-	glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
-	glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE); // needed for mac?
-	glfwWindowHint(GLFW_OPENGL_DEBUG_CONTEXT, GL_TRUE);
+	// XXX(beau): handle errors?
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
+	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_FORWARD_COMPATIBLE_FLAG);
 
+	window = std::unique_ptr<SDL_Window, WindowDeleter>(SDL_CreateWindow("CPSC 453", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL));
+	if (!window)
+		sdl_error_handler(1);
 	// create window
-	window = std::unique_ptr<GLFWwindow, WindowDeleter>(glfwCreateWindow(width, height, title, monitor, share));
-	if (window == nullptr) {
-		Log::error("WINDOW failed to create GLFW window");
-		throw std::runtime_error("Failed to create GLFW window.");
-	}
-	glfwMakeContextCurrent(window.get());
+	// window = std::unique_ptr<GLFWwindow, WindowDeleter>(glfwCreateWindow(width, height, title, monitor, share));
+	//
+	// if (window == nullptr) {
+	// 	Log::error("WINDOW failed to create GLFW window");
+	// 	throw std::runtime_error("Failed to create GLFW window.");
+	// }
+	// glfwMakeContextCurrent(window.get());
+
+	// TODO:(beau) clean up
+	if (!SDL_GL_CreateContext(window.get()))
+		sdl_error_handler(1);
+
+	// vsync
+	sdl_error_handler(SDL_GL_SetSwapInterval(1));
 
 	// initialize OpenGL extensions for the current context (this window)
 	GLenum err = glewInit();
@@ -72,11 +92,11 @@ Window::Window(
 		throw std::runtime_error("Failed to initialize GLEW");
 	}
 
-	glfwSetWindowSizeCallback(window.get(), defaultWindowSizeCallback);
+	// glfwSetWindowSizeCallback(window.get(), defaultWindowSizeCallback);
 
-	if (callbacks != nullptr) {
-		connectCallbacks();
-	}
+	// if (callbacks != nullptr) {
+	// 	connectCallbacks();
+	// }
 }
 
 
@@ -87,14 +107,14 @@ Window::Window(int width, int height, const char* title, GLFWmonitor* monitor, G
 
 void Window::connectCallbacks() {
 	// set userdata of window to point to the object that carries out the callbacks
-	glfwSetWindowUserPointer(window.get(), callbacks.get());
+	// glfwSetWindowUserPointer(window.get(), callbacks.get());
 
 	// bind meta callbacks to actual callbacks
-	glfwSetKeyCallback(window.get(), keyMetaCallback);
-	glfwSetMouseButtonCallback(window.get(), mouseButtonMetaCallback);
-	glfwSetCursorPosCallback(window.get(), cursorPosMetaCallback);
-	glfwSetScrollCallback(window.get(), scrollMetaCallback);
-	glfwSetWindowSizeCallback(window.get(), windowSizeMetaCallback);
+	// glfwSetKeyCallback(window.get(), keyMetaCallback);
+	// glfwSetMouseButtonCallback(window.get(), mouseButtonMetaCallback);
+	// glfwSetCursorPosCallback(window.get(), cursorPosMetaCallback);
+	// glfwSetScrollCallback(window.get(), scrollMetaCallback);
+	// glfwSetWindowSizeCallback(window.get(), windowSizeMetaCallback);
 }
 
 
@@ -106,13 +126,13 @@ void Window::setCallbacks(std::shared_ptr<CallbackInterface> callbacks_) {
 
 glm::ivec2 Window::getPos() const {
 	int x, y;
-	glfwGetWindowPos(window.get(), &x, &y);
+	// glfwGetWindowPos(window.get(), &x, &y);
 	return glm::ivec2(x, y);
 }
 
 
 glm::ivec2 Window::getSize() const {
 	int w, h;
-	glfwGetWindowSize(window.get(), &w, &h);
+	// glfwGetWindowSize(window.get(), &w, &h);
 	return glm::ivec2(w, h);
 }

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -75,7 +75,8 @@ Window::Window(
 		sdl_error_handler(1);
 
 	// TODO:(beau) clean up
-	if (!SDL_GL_CreateContext(window.get()))
+	SDL_GLContext context = SDL_GL_CreateContext(window.get());
+	if (!context)
 		sdl_error_handler(1);
 
 	// vsync
@@ -87,6 +88,16 @@ Window::Window(
 		Log::error("WINDOW glewInit error:{}", glewGetErrorString(err));
 		throw std::runtime_error("Failed to initialize GLEW");
 	}
+
+	// TODO(beau): put this somewhere obvious
+	IMGUI_CHECKVERSION();
+	ImGui::CreateContext();
+	ImGuiIO& io = ImGui::GetIO(); (void)io;
+
+	ImGui::StyleColorsDark();
+
+	ImGui_ImplSDL2_InitForOpenGL(window.get(), context);
+	ImGui_ImplOpenGL3_Init("#version 330");
 }
 
 

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -17,8 +17,8 @@ Window::Window(int width, int height, const char* title)
 {
 	// specify OpenGL version
 	// XXX(beau): handle errors?
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 3);
-	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 4);
+	SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 6);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_CORE);
 	SDL_GL_SetAttribute(SDL_GL_DOUBLEBUFFER, 1);
 	SDL_GL_SetAttribute(SDL_GL_CONTEXT_FLAGS, SDL_GL_CONTEXT_DEBUG_FLAG);
@@ -50,7 +50,7 @@ Window::Window(int width, int height, const char* title)
 	ImGui::StyleColorsDark();
 
 	ImGui_ImplSDL2_InitForOpenGL(window.get(), context);
-	ImGui_ImplOpenGL3_Init("#version 330");
+	ImGui_ImplOpenGL3_Init("#version 460 core");
 }
 
 

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -16,34 +16,37 @@ void sdl_error_handler(int sdl_return) {
 // static function definitions
 // ---------------------------
 
-void Window::keyMetaCallback(GLFWwindow* window, int key, int scancode, int action, int mods) {
-	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-	callbacks->keyCallback(key, scancode, action, mods);
-}
+// TODO(beau): decide if we want to use callbacks for input handling, or
+//             or just handle input events in main. If the latter, scrap
+//             all this callback stuff
+// void Window::keyMetaCallback(SDL_Window* window, int key, int scancode, int action, int mods) {
+// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
+// 	callbacks->keyCallback(key, scancode, action, mods);
+// }
 
 
-void Window::mouseButtonMetaCallback(GLFWwindow* window, int button, int action, int mods) {
-	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-	callbacks->mouseButtonCallback(button, action, mods);
-}
+// void Window::mouseButtonMetaCallback(SDL_Window* window, int button, int action, int mods) {
+// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
+// 	callbacks->mouseButtonCallback(button, action, mods);
+// }
 
 
-void Window::cursorPosMetaCallback(GLFWwindow* window, double xpos, double ypos) {
-	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-	callbacks->cursorPosCallback(xpos, ypos);
-}
+// void Window::cursorPosMetaCallback(SDL_Window* window, double xpos, double ypos) {
+// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
+// 	callbacks->cursorPosCallback(xpos, ypos);
+// }
 
 
-void Window::scrollMetaCallback(GLFWwindow* window, double xoffset, double yoffset) {
-	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-	callbacks->scrollCallback(xoffset, yoffset);
-}
+// void Window::scrollMetaCallback(SDL_Window* window, double xoffset, double yoffset) {
+// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
+// 	callbacks->scrollCallback(xoffset, yoffset);
+// }
 
 
-void Window::windowSizeMetaCallback(GLFWwindow* window, int width, int height) {
-	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-	callbacks->windowSizeCallback(width, height);
-}
+// void Window::windowSizeMetaCallback(SDL_Window* window, int width, int height) {
+// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
+// 	callbacks->windowSizeCallback(width, height);
+// }
 
 
 // ----------------------
@@ -51,9 +54,10 @@ void Window::windowSizeMetaCallback(GLFWwindow* window, int width, int height) {
 // ----------------------
 
 Window::Window(
-	std::shared_ptr<CallbackInterface> callbacks, int width, int height,
-	const char* title, GLFWmonitor* monitor, GLFWwindow* share
-)
+// TODO(beau): decide if we want to use callbacks for input handling, or
+//             or just handle input events in main. If the latter, scrap
+//             all this callback stuff
+	std::shared_ptr<CallbackInterface> callbacks, int width, int height, const char* title)
 	: window(nullptr)
 	, callbacks(callbacks)
 {
@@ -69,14 +73,6 @@ Window::Window(
 	window = std::unique_ptr<SDL_Window, WindowDeleter>(SDL_CreateWindow("CPSC 453", SDL_WINDOWPOS_CENTERED, SDL_WINDOWPOS_CENTERED, width, height, SDL_WINDOW_OPENGL));
 	if (!window)
 		sdl_error_handler(1);
-	// create window
-	// window = std::unique_ptr<GLFWwindow, WindowDeleter>(glfwCreateWindow(width, height, title, monitor, share));
-	//
-	// if (window == nullptr) {
-	// 	Log::error("WINDOW failed to create GLFW window");
-	// 	throw std::runtime_error("Failed to create GLFW window.");
-	// }
-	// glfwMakeContextCurrent(window.get());
 
 	// TODO:(beau) clean up
 	if (!SDL_GL_CreateContext(window.get()))
@@ -91,21 +87,18 @@ Window::Window(
 		Log::error("WINDOW glewInit error:{}", glewGetErrorString(err));
 		throw std::runtime_error("Failed to initialize GLEW");
 	}
-
-	// glfwSetWindowSizeCallback(window.get(), defaultWindowSizeCallback);
-
-	// if (callbacks != nullptr) {
-	// 	connectCallbacks();
-	// }
 }
 
 
-Window::Window(int width, int height, const char* title, GLFWmonitor* monitor, GLFWwindow* share)
-	: Window(nullptr, width, height, title, monitor, share)
+Window::Window(int width, int height, const char* title)
+	: Window(nullptr, width, height, title)
 {}
 
 
-void Window::connectCallbacks() {
+// TODO(beau): decide if we want to use callbacks for input handling, or
+//             or just handle input events in main. If the latter, scrap
+//             all this callback stuff
+// void Window::connectCallbacks() {
 	// set userdata of window to point to the object that carries out the callbacks
 	// glfwSetWindowUserPointer(window.get(), callbacks.get());
 
@@ -115,24 +108,27 @@ void Window::connectCallbacks() {
 	// glfwSetCursorPosCallback(window.get(), cursorPosMetaCallback);
 	// glfwSetScrollCallback(window.get(), scrollMetaCallback);
 	// glfwSetWindowSizeCallback(window.get(), windowSizeMetaCallback);
-}
+// }
 
 
-void Window::setCallbacks(std::shared_ptr<CallbackInterface> callbacks_) {
-	callbacks = callbacks_;
-	connectCallbacks();
-}
+// TODO(beau): decide if we want to use callbacks for input handling, or
+//             or just handle input events in main. If the latter, scrap
+//             all this callback stuff
+// void Window::setCallbacks(std::shared_ptr<CallbackInterface> callbacks_) {
+// 	callbacks = callbacks_;
+// 	connectCallbacks();
+// }
 
 
 glm::ivec2 Window::getPos() const {
 	int x, y;
-	// glfwGetWindowPos(window.get(), &x, &y);
+	SDL_GetWindowPosition(window.get(), &x, &y);
 	return glm::ivec2(x, y);
 }
 
 
 glm::ivec2 Window::getSize() const {
 	int w, h;
-	// glfwGetWindowSize(window.get(), &w, &h);
+	SDL_GetWindowSize(window.get(), &w, &h);
 	return glm::ivec2(w, h);
 }

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -12,54 +12,8 @@ void sdl_error_handler(int sdl_return) {
 }
 
 
-// ---------------------------
-// static function definitions
-// ---------------------------
-
-// TODO(beau): decide if we want to use callbacks for input handling, or
-//             or just handle input events in main. If the latter, scrap
-//             all this callback stuff
-// void Window::keyMetaCallback(SDL_Window* window, int key, int scancode, int action, int mods) {
-// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-// 	callbacks->keyCallback(key, scancode, action, mods);
-// }
-
-
-// void Window::mouseButtonMetaCallback(SDL_Window* window, int button, int action, int mods) {
-// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-// 	callbacks->mouseButtonCallback(button, action, mods);
-// }
-
-
-// void Window::cursorPosMetaCallback(SDL_Window* window, double xpos, double ypos) {
-// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-// 	callbacks->cursorPosCallback(xpos, ypos);
-// }
-
-
-// void Window::scrollMetaCallback(SDL_Window* window, double xoffset, double yoffset) {
-// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-// 	callbacks->scrollCallback(xoffset, yoffset);
-// }
-
-
-// void Window::windowSizeMetaCallback(SDL_Window* window, int width, int height) {
-// 	CallbackInterface* callbacks = static_cast<CallbackInterface*>(glfwGetWindowUserPointer(window));
-// 	callbacks->windowSizeCallback(width, height);
-// }
-
-
-// ----------------------
-// non-static definitions
-// ----------------------
-
-Window::Window(
-// TODO(beau): decide if we want to use callbacks for input handling, or
-//             or just handle input events in main. If the latter, scrap
-//             all this callback stuff
-	std::shared_ptr<CallbackInterface> callbacks, int width, int height, const char* title)
+Window::Window(int width, int height, const char* title)
 	: window(nullptr)
-	, callbacks(callbacks)
 {
 	// specify OpenGL version
 	// XXX(beau): handle errors?
@@ -99,36 +53,6 @@ Window::Window(
 	ImGui_ImplSDL2_InitForOpenGL(window.get(), context);
 	ImGui_ImplOpenGL3_Init("#version 330");
 }
-
-
-Window::Window(int width, int height, const char* title)
-	: Window(nullptr, width, height, title)
-{}
-
-
-// TODO(beau): decide if we want to use callbacks for input handling, or
-//             or just handle input events in main. If the latter, scrap
-//             all this callback stuff
-// void Window::connectCallbacks() {
-	// set userdata of window to point to the object that carries out the callbacks
-	// glfwSetWindowUserPointer(window.get(), callbacks.get());
-
-	// bind meta callbacks to actual callbacks
-	// glfwSetKeyCallback(window.get(), keyMetaCallback);
-	// glfwSetMouseButtonCallback(window.get(), mouseButtonMetaCallback);
-	// glfwSetCursorPosCallback(window.get(), cursorPosMetaCallback);
-	// glfwSetScrollCallback(window.get(), scrollMetaCallback);
-	// glfwSetWindowSizeCallback(window.get(), windowSizeMetaCallback);
-// }
-
-
-// TODO(beau): decide if we want to use callbacks for input handling, or
-//             or just handle input events in main. If the latter, scrap
-//             all this callback stuff
-// void Window::setCallbacks(std::shared_ptr<CallbackInterface> callbacks_) {
-// 	callbacks = callbacks_;
-// 	connectCallbacks();
-// }
 
 
 glm::ivec2 Window::getPos() const {

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -46,7 +46,6 @@ Window::Window(int width, int height, const char* title)
 	// TODO(beau): put this somewhere obvious
 	IMGUI_CHECKVERSION();
 	ImGui::CreateContext();
-	ImGuiIO& io = ImGui::GetIO(); (void)io;
 
 	ImGui::StyleColorsDark();
 

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -50,6 +50,8 @@ Window::Window(int width, int height, const char* title)
 	ImGui::StyleColorsDark();
 
 	ImGui_ImplSDL2_InitForOpenGL(window.get(), context);
+
+	// VOLATILE: must match version specified in shaders!
 	ImGui_ImplOpenGL3_Init("#version 460 core");
 }
 

--- a/code/client/Window.cpp
+++ b/code/client/Window.cpp
@@ -1,3 +1,12 @@
+// TODO(beau): sdl cleanup:
+//             There are a number of sdl things we could clean up, we simply need to figure out when/where
+//             - SDL_Quit()
+//             - clean up OpenGL context (will we switch contexts?)
+//             - clean up the window?
+//             - other things iirc
+//             IMO these things will become more clear once we know more about the architecture of our program.
+//             For now, we can leave these things as we're not leaking memory and the OS is cleaning up after us.
+//             Note that the glfw code also didn't do a great job of cleaning up after itself
 #include "Window.h"
 
 #include "Log.h"
@@ -28,7 +37,6 @@ Window::Window(int width, int height, const char* title)
 	if (!window)
 		sdl_error_handler(1);
 
-	// TODO:(beau) clean up
 	SDL_GLContext context = SDL_GL_CreateContext(window.get());
 	if (!context)
 		sdl_error_handler(1);

--- a/code/client/Window.h
+++ b/code/client/Window.h
@@ -47,8 +47,7 @@ struct Window {
 	int getWidth() const { return getSize().x; }
 	int getHeight() const { return getSize().y; }
 
-	// NOTE(beau): leave this in in case we need to change contexts, but refactor to sdl2
-	// void makeContextCurrent() { glfwMakeContextCurrent(window.get()); }
+	// NOTE(beau): make current context method?
 
 	void swapBuffers() { SDL_GL_SwapWindow(window.get()); }
 

--- a/code/client/Window.h
+++ b/code/client/Window.h
@@ -9,6 +9,10 @@
 #include <GLFW/glfw3.h>
 #include <glm/glm.hpp>
 
+#include "SDL.h"
+#include "SDL_main.h"
+#include "SDL_opengl.h"
+
 #include <memory>
 
 
@@ -31,8 +35,8 @@ public:
 // This is used as a custom deleter with std::unique_ptr so that the window
 // is properly destroyed when std::unique_ptr needs to clean up its resource
 struct WindowDeleter {
-	void operator() (GLFWwindow* window) const {
-		glfwDestroyWindow(window);
+	void operator() (SDL_Window* window) const {
+		SDL_DestroyWindow(window);
 	}
 };
 
@@ -59,11 +63,11 @@ public:
 	int getWidth() const { return getSize().x; }
 	int getHeight() const { return getSize().y; }
 
-	int shouldClose() { return glfwWindowShouldClose(window.get()); }
-	void makeContextCurrent() { glfwMakeContextCurrent(window.get()); }
-	void swapBuffers() { glfwSwapBuffers(window.get()); }
+	// int shouldClose() { return glfwWindowShouldClose(window.get()); }
+	// void makeContextCurrent() { glfwMakeContextCurrent(window.get()); }
+	// void swapBuffers() { glfwSwapBuffers(window.get()); }
 
-	std::unique_ptr<GLFWwindow, WindowDeleter> window; // owning ptr (from GLFW)
+	std::unique_ptr<SDL_Window, WindowDeleter> window; // owning ptr (from GLFW)
 	std::shared_ptr<CallbackInterface> callbacks;      // optional shared owning ptr (user provided)
 
 	void connectCallbacks();

--- a/code/client/Window.h
+++ b/code/client/Window.h
@@ -6,7 +6,7 @@
 //------------------------------------------------------------------------------
 
 #include <GL/glew.h>
-#include <GLFW/glfw3.h>
+#include <SDL_render.h>
 #include <glm/glm.hpp>
 
 #include "SDL.h"
@@ -16,6 +16,9 @@
 #include <memory>
 
 
+// TODO(beau): decide if we want to use callbacks for input handling, or
+//             or just handle input events in main. If the latter, scrap
+//             all this callback stuff
 // Class that specifies the interface for the most common GLFW callbacks
 //
 // These are the default implementations. You can write your own class that
@@ -30,7 +33,7 @@ public:
 };
 
 
-// Functor for deleting a GLFW window.
+// Functor for deleting a SDL window.
 //
 // This is used as a custom deleter with std::unique_ptr so that the window
 // is properly destroyed when std::unique_ptr needs to clean up its resource
@@ -41,17 +44,25 @@ struct WindowDeleter {
 };
 
 
-// Main class for creating and interacting with a GLFW window.
+// Main class for creating and interacting with a SDL window.
 // Only wraps the most fundamental parts of the API
 class Window {
 
 public:
+	// TODO(beau): decide if we want to use callbacks for input handling, or
+	//             or just handle input events in main. If the latter, scrap
+	//             all this callback stuff
 	Window(
-		std::shared_ptr<CallbackInterface> callbacks, int width, int height,
-		const char* title, GLFWmonitor* monitor = NULL, GLFWwindow* share = NULL
+		std::shared_ptr<CallbackInterface> callbacks, int width, int height, const char* title
 	);
-	Window(int width, int height, const char* title, GLFWmonitor* monitor = NULL, GLFWwindow* share = NULL);
+	Window(int width, int height, const char* title);
 
+
+
+
+	// TODO(beau): decide if we want to use callbacks for input handling, or
+	//             or just handle input events in main. If the latter, scrap
+	//             all this callback stuff
 	void setCallbacks(std::shared_ptr<CallbackInterface> callbacks);
 
 	glm::ivec2 getPos() const;
@@ -63,23 +74,36 @@ public:
 	int getWidth() const { return getSize().x; }
 	int getHeight() const { return getSize().y; }
 
-	// int shouldClose() { return glfwWindowShouldClose(window.get()); }
+	// NOTE(beau): leave this in in case we need to change contexts
 	// void makeContextCurrent() { glfwMakeContextCurrent(window.get()); }
-	// void swapBuffers() { glfwSwapBuffers(window.get()); }
 
+	void swapBuffers() { SDL_GL_SwapWindow(window.get()); }
+
+
+	// NOTE(beau): I *think* this should be here so we can do the callback thing like before,
+	// BUT if we don't have to do that why not just switch on the sdl event in the render loop
+	SDL_Event event;
+
+private:
 	std::unique_ptr<SDL_Window, WindowDeleter> window; // owning ptr (from GLFW)
+	// TODO(beau): decide if we want to use callbacks for input handling, or
+	//             or just handle input events in main. If the latter, scrap
+	//             all this callback stuff
 	std::shared_ptr<CallbackInterface> callbacks;      // optional shared owning ptr (user provided)
 
-	void connectCallbacks();
+	// void connectCallbacks();
 
-	static void defaultWindowSizeCallback(GLFWwindow* window, int width, int height) { glViewport(0, 0, width, height); }
+	// static void defaultWindowSizeCallback(SDL_Window* window, int width, int height) { glViewport(0, 0, width, height); }
 
+	// TODO(beau): decide if we want to use callbacks for input handling, or
+	//             or just handle input events in main. If the latter, scrap
+	//             all this callback stuff
 	// Meta callback functions. These bind to the actual glfw callback,
 	// get the actual callback method from user data, and then call that.
-	static void keyMetaCallback(GLFWwindow* window, int key, int scancode, int action, int mods);
-	static void mouseButtonMetaCallback(GLFWwindow* window, int button, int action, int mods);
-	static void cursorPosMetaCallback(GLFWwindow* window, double xpos, double ypos);
-	static void scrollMetaCallback(GLFWwindow* window, double xoffset, double yoffset);
-	static void windowSizeMetaCallback(GLFWwindow* window, int width, int height);
+	// static void keyMetaCallback(SDL_Window* window, int key, int scancode, int action, int mods);
+	// static void mouseButtonMetaCallback(SDL_Window* window, int button, int action, int mods);
+	// static void cursorPosMetaCallback(SDL_Window* window, double xpos, double ypos);
+	// static void scrollMetaCallback(SDL_Window* window, double xoffset, double yoffset);
+	// static void windowSizeMetaCallback(SDL_Window* window, int width, int height);
 };
 

--- a/code/client/Window.h
+++ b/code/client/Window.h
@@ -2,7 +2,7 @@
 
 //------------------------------------------------------------------------------
 // This file contains classes that provide a simpler and safer interface for
-// interacting with a GLFW window following RAII principles
+// interacting with a SDL window following RAII principles
 //------------------------------------------------------------------------------
 
 #include <GL/glew.h>
@@ -74,7 +74,7 @@ public:
 	int getWidth() const { return getSize().x; }
 	int getHeight() const { return getSize().y; }
 
-	// NOTE(beau): leave this in in case we need to change contexts
+	// NOTE(beau): leave this in in case we need to change contexts, but refactor to sdl2
 	// void makeContextCurrent() { glfwMakeContextCurrent(window.get()); }
 
 	void swapBuffers() { SDL_GL_SwapWindow(window.get()); }
@@ -85,7 +85,8 @@ public:
 	SDL_Event event;
 
 private:
-	std::unique_ptr<SDL_Window, WindowDeleter> window; // owning ptr (from GLFW)
+	std::unique_ptr<SDL_Window, WindowDeleter> window; // owning ptr (from SDL)
+
 	// TODO(beau): decide if we want to use callbacks for input handling, or
 	//             or just handle input events in main. If the latter, scrap
 	//             all this callback stuff

--- a/code/client/Window.h
+++ b/code/client/Window.h
@@ -13,6 +13,11 @@
 #include "SDL_main.h"
 #include "SDL_opengl.h"
 
+#include "imgui.h"
+#include "imgui_impl_sdl.h"
+#include "imgui_impl_sdlrenderer.h"
+#include "imgui_impl_opengl3.h"
+
 #include <memory>
 
 
@@ -84,7 +89,6 @@ public:
 	// BUT if we don't have to do that why not just switch on the sdl event in the render loop
 	SDL_Event event;
 
-private:
 	std::unique_ptr<SDL_Window, WindowDeleter> window; // owning ptr (from SDL)
 
 	// TODO(beau): decide if we want to use callbacks for input handling, or

--- a/code/client/Window.h
+++ b/code/client/Window.h
@@ -21,22 +21,6 @@
 #include <memory>
 
 
-// TODO(beau): decide if we want to use callbacks for input handling, or
-//             or just handle input events in main. If the latter, scrap
-//             all this callback stuff
-// Class that specifies the interface for the most common GLFW callbacks
-//
-// These are the default implementations. You can write your own class that
-// extends this one and overrides the implementations with your own
-class CallbackInterface {
-public:
-	virtual void keyCallback(int key, int scancode, int action, int mods) {}
-	virtual void mouseButtonCallback(int button, int action, int mods) {}
-	virtual void cursorPosCallback(double xpos, double ypos) {}
-	virtual void scrollCallback(double xoffset, double yoffset) {}
-	virtual void windowSizeCallback(int width, int height) { glViewport(0, 0, width, height); }
-};
-
 
 // Functor for deleting a SDL window.
 //
@@ -51,24 +35,8 @@ struct WindowDeleter {
 
 // Main class for creating and interacting with a SDL window.
 // Only wraps the most fundamental parts of the API
-class Window {
-
-public:
-	// TODO(beau): decide if we want to use callbacks for input handling, or
-	//             or just handle input events in main. If the latter, scrap
-	//             all this callback stuff
-	Window(
-		std::shared_ptr<CallbackInterface> callbacks, int width, int height, const char* title
-	);
+struct Window {
 	Window(int width, int height, const char* title);
-
-
-
-
-	// TODO(beau): decide if we want to use callbacks for input handling, or
-	//             or just handle input events in main. If the latter, scrap
-	//             all this callback stuff
-	void setCallbacks(std::shared_ptr<CallbackInterface> callbacks);
 
 	glm::ivec2 getPos() const;
 	glm::ivec2 getSize() const;
@@ -84,31 +52,7 @@ public:
 
 	void swapBuffers() { SDL_GL_SwapWindow(window.get()); }
 
-
-	// NOTE(beau): I *think* this should be here so we can do the callback thing like before,
-	// BUT if we don't have to do that why not just switch on the sdl event in the render loop
 	SDL_Event event;
 
 	std::unique_ptr<SDL_Window, WindowDeleter> window; // owning ptr (from SDL)
-
-	// TODO(beau): decide if we want to use callbacks for input handling, or
-	//             or just handle input events in main. If the latter, scrap
-	//             all this callback stuff
-	std::shared_ptr<CallbackInterface> callbacks;      // optional shared owning ptr (user provided)
-
-	// void connectCallbacks();
-
-	// static void defaultWindowSizeCallback(SDL_Window* window, int width, int height) { glViewport(0, 0, width, height); }
-
-	// TODO(beau): decide if we want to use callbacks for input handling, or
-	//             or just handle input events in main. If the latter, scrap
-	//             all this callback stuff
-	// Meta callback functions. These bind to the actual glfw callback,
-	// get the actual callback method from user data, and then call that.
-	// static void keyMetaCallback(SDL_Window* window, int key, int scancode, int action, int mods);
-	// static void mouseButtonMetaCallback(SDL_Window* window, int button, int action, int mods);
-	// static void cursorPosMetaCallback(SDL_Window* window, double xpos, double ypos);
-	// static void scrollMetaCallback(SDL_Window* window, double xoffset, double yoffset);
-	// static void windowSizeMetaCallback(SDL_Window* window, int width, int height);
 };
-

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -1,10 +1,13 @@
 #include <GL/glew.h>
-#include <GLFW/glfw3.h>
+// #include <GLFW/glfw3.h>
+
 
 #include <iostream>
 
 #include "imgui.h"
-#include "imgui_impl_glfw.h"
+// #include "imgui_impl_glfw.h"
+#include "imgui_impl_sdl.h"
+#include "imgui_impl_sdlrenderer.h"
 #include "imgui_impl_opengl3.h"
 
 #include "Geometry.h"
@@ -20,30 +23,30 @@ CarPhysics carPhysics;
 CarPhysicsSerde carConfig(carPhysics);
 
 // EXAMPLE CALLBACKS
-class MyCallbacks : public CallbackInterface {
+// class MyCallbacks : public CallbackInterface {
 
-public:
-	MyCallbacks(ShaderProgram& shader) : shader(shader) {}
+// public:
+// 	MyCallbacks(ShaderProgram& shader) : shader(shader) {}
 
-	virtual void keyCallback(int key, int scancode, int action, int mods) {
-		if (key == GLFW_KEY_R && action == GLFW_PRESS)
-			shader.recompile();
+// 	virtual void keyCallback(int key, int scancode, int action, int mods) {
+// 		if (key == GLFW_KEY_R && action == GLFW_PRESS)
+// 			shader.recompile();
 
-		// press t to hot-reload car physics config
-		if (key == GLFW_KEY_T && action == GLFW_PRESS)
-			carConfig.deserialize();
+// 		// press t to hot-reload car physics config
+// 		if (key == GLFW_KEY_T && action == GLFW_PRESS)
+// 			carConfig.deserialize();
 
-		// press s to serialize current car config
-		if (key == GLFW_KEY_S && action == GLFW_PRESS)
-			carConfig.serialize();
-	}
+// 		// press s to serialize current car config
+// 		if (key == GLFW_KEY_S && action == GLFW_PRESS)
+// 			carConfig.serialize();
+// 	}
 
-	virtual void cursorPosCallback(double xpos, double ypos) {
-	}
+// 	virtual void cursorPosCallback(double xpos, double ypos) {
+// 	}
 
-private:
-	ShaderProgram& shader;
-};
+// private:
+// 	ShaderProgram& shader;
+// };
 
 
 std::vector<glm::vec3> drawFromMidpoints(std::vector<glm::vec3> src);
@@ -128,90 +131,101 @@ std::vector<glm::vec3> colourSquare(std::vector<glm::vec3> dest, glm::vec3 colou
 
 }
 
-int main() {
+int main(int argc, char* argv[]) {
 	Log::debug("Starting main");
 
 	// WINDOW
-	glfwInit();
+	SDL_Init(SDL_INIT_EVERYTHING);
 	Window window(800, 800, "CPSC 453"); // can set callbacks at construction if desired
 
 	GLDebug::enable();
 
 	// SHADERS
-	ShaderProgram shader("shaders/test.vert", "shaders/test.frag");
+	// ShaderProgram shader("shaders/test.vert", "shaders/test.frag");
 
 	// CALLBACKS
-	window.setCallbacks(std::make_shared<MyCallbacks>(shader)); // can also update callbacks to new ones
+	// window.setCallbacks(std::make_shared<MyCallbacks>(shader)); // can also update callbacks to new ones
 
 
 	// GEOMETRY
-	CPU_Geometry cpuGeom;
-	GPU_Geometry gpuGeom;
+	// CPU_Geometry cpuGeom;
+	// GPU_Geometry gpuGeom;
 
-	cpuGeom = squaresDiamonds(glm::vec3(0.8, -0.8, 0), glm::vec3(0.8, 0.8, 0), glm::vec3(-0.8, 0.8, 0), glm::vec3(-0.8, -0.8, 0), 3);
+	// cpuGeom = squaresDiamonds(glm::vec3(0.8, -0.8, 0), glm::vec3(0.8, 0.8, 0), glm::vec3(-0.8, 0.8, 0), glm::vec3(-0.8, -0.8, 0), 3);
 
 
-	for (int i = 0; i < cpuGeom.verts.size(); i++) {
-		std::cout << cpuGeom.verts[i] << std::endl;
-	}
+	// for (int i = 0; i < cpuGeom.verts.size(); i++) {
+	// 	std::cout << cpuGeom.verts[i] << std::endl;
+	// }
 
-	gpuGeom.setVerts(cpuGeom.verts);
-	gpuGeom.setCols(cpuGeom.cols);
+	// gpuGeom.setVerts(cpuGeom.verts);
+	// gpuGeom.setCols(cpuGeom.cols);
 
-	carConfig.deserialize();
+	// carConfig.deserialize();
 
 	// NOTE(beau): put this somewhere else
 	// It's not in the window constructor because input won't
 	// work unless this code is called after the window callbacks are set
-	IMGUI_CHECKVERSION();
-	ImGui::CreateContext();
-	ImGuiIO& io = ImGui::GetIO(); (void)io;
+	// IMGUI_CHECKVERSION();
+	// ImGui::CreateContext();
+	// ImGuiIO& io = ImGui::GetIO(); (void)io;
 
-	ImGui::StyleColorsDark();
+	// ImGui::StyleColorsDark();
 
-	ImGui_ImplOpenGL3_Init("#version 330");
-	ImGui_ImplGlfw_InitForOpenGL(window.window.get(), true);
+	// ImGui_ImplOpenGL3_Init("#version 330");
+	// ImGui_ImplGlfw_InitForOpenGL(window.window.get(), true);
 
 	// RENDER LOOP
-	while (!window.shouldClose()) {
-		glfwPollEvents();
+	// while (!window.shouldClose()) {
+	bool quit = false;
+	SDL_Event event;
+	while (!quit) {
+		while (SDL_PollEvent(&event)) {
+			if (event.type == SDL_QUIT) {
+				quit = true;
+			}
+		}
 
-		shader.use();
-		gpuGeom.bind();
+		// glfwPollEvents();
+
+		// shader.use();
+		// gpuGeom.bind();
 
 		glEnable(GL_FRAMEBUFFER_SRGB);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
 		//std::cout << GLsizei(cpuGeom.verts.size());
 
-		for (int i = 0; i < GLsizei(cpuGeom.verts.size()); i+=4)
-		{
-			glDrawArrays(GL_LINE_LOOP, i, 4);
-		}
+		// for (int i = 0; i < GLsizei(cpuGeom.verts.size()); i+=4)
+		// {
+		// 	glDrawArrays(GL_LINE_LOOP, i, 4);
+		// }
 
 		glDisable(GL_FRAMEBUFFER_SRGB); // disable sRGB for things like imgui
 
-		ImGui_ImplOpenGL3_NewFrame();
-		ImGui_ImplGlfw_NewFrame();
-		ImGui::NewFrame();
+		// ImGui_ImplOpenGL3_NewFrame();
+		// ImGui_ImplGlfw_NewFrame();
+		// ImGui::NewFrame();
 
-		ImGui::Begin("Car Physics", nullptr);
+		// ImGui::Begin("Car Physics", nullptr);
 
-		ImGui::SliderFloat("acceleration", &carPhysics.m_acceleration, 0.f, 1000.f);
-		ImGui::SliderFloat("suspension", &carPhysics.m_suspension_force, 0.f, 1000.f);
+		// ImGui::SliderFloat("acceleration", &carPhysics.m_acceleration, 0.f, 1000.f);
+		// ImGui::SliderFloat("suspension", &carPhysics.m_suspension_force, 0.f, 1000.f);
 
-		ImGui::End();
+		// ImGui::End();
 
-		ImGui::Render();
-		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+		// ImGui::Render();
+		// ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-		window.swapBuffers();
+		// window.swapBuffers();
+		SDL_GL_SwapWindow(window.window.get());
 	}
 
-	ImGui_ImplOpenGL3_Shutdown();
-	ImGui_ImplGlfw_Shutdown();
-	ImGui::DestroyContext();
+	// ImGui_ImplOpenGL3_Shutdown();
+	// ImGui_ImplGlfw_Shutdown();
+	// ImGui::DestroyContext();
 
-	glfwTerminate();
+	SDL_Quit();
+	// glfwTerminate();
 	return 0;
 }

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -19,36 +19,6 @@
 CarPhysics carPhysics;
 CarPhysicsSerde carConfig(carPhysics);
 
-// TODO(beau): decide if we want to use callbacks for input handling, or
-//             or just handle input events in main. If the latter, scrap
-//             all this callback stuff
-// EXAMPLE CALLBACKS
-// class MyCallbacks : public CallbackInterface {
-
-// public:
-// 	MyCallbacks(ShaderProgram& shader) : shader(shader) {}
-
-// 	virtual void keyCallback(int key, int scancode, int action, int mods) {
-// 		if (key == GLFW_KEY_R && action == GLFW_PRESS)
-// 			shader.recompile();
-
-// 		// press t to hot-reload car physics config
-// 		if (key == GLFW_KEY_T && action == GLFW_PRESS)
-// 			carConfig.deserialize();
-
-// 		// press s to serialize current car config
-// 		if (key == GLFW_KEY_S && action == GLFW_PRESS)
-// 			carConfig.serialize();
-// 	}
-
-// 	virtual void cursorPosCallback(double xpos, double ypos) {
-// 	}
-
-// private:
-// 	ShaderProgram& shader;
-// };
-
-
 std::vector<glm::vec3> drawFromMidpoints(std::vector<glm::vec3> src);
 std::vector<glm::vec3> colourSquare(std::vector<glm::vec3> dest, glm::vec3 colour);
 
@@ -141,10 +111,6 @@ int main(int argc, char* argv[]) {
 
 	// SHADERS
 	ShaderProgram shader("shaders/test.vert", "shaders/test.frag");
-
-	// CALLBACKS
-	// window.setCallbacks(std::make_shared<MyCallbacks>(shader)); // can also update callbacks to new ones
-
 
 	// GEOMETRY
 	CPU_Geometry cpuGeom;

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -143,27 +143,27 @@ int main(int argc, char* argv[]) {
 	GLDebug::enable();
 
 	// SHADERS
-	// ShaderProgram shader("shaders/test.vert", "shaders/test.frag");
+	ShaderProgram shader("shaders/test.vert", "shaders/test.frag");
 
 	// CALLBACKS
 	// window.setCallbacks(std::make_shared<MyCallbacks>(shader)); // can also update callbacks to new ones
 
 
 	// GEOMETRY
-	// CPU_Geometry cpuGeom;
-	// GPU_Geometry gpuGeom;
+	CPU_Geometry cpuGeom;
+	GPU_Geometry gpuGeom;
 
-	// cpuGeom = squaresDiamonds(glm::vec3(0.8, -0.8, 0), glm::vec3(0.8, 0.8, 0), glm::vec3(-0.8, 0.8, 0), glm::vec3(-0.8, -0.8, 0), 3);
+	cpuGeom = squaresDiamonds(glm::vec3(0.8, -0.8, 0), glm::vec3(0.8, 0.8, 0), glm::vec3(-0.8, 0.8, 0), glm::vec3(-0.8, -0.8, 0), 3);
 
 
-	// for (int i = 0; i < cpuGeom.verts.size(); i++) {
-	// 	std::cout << cpuGeom.verts[i] << std::endl;
-	// }
+	for (int i = 0; i < cpuGeom.verts.size(); i++) {
+		std::cout << cpuGeom.verts[i] << std::endl;
+	}
 
-	// gpuGeom.setVerts(cpuGeom.verts);
-	// gpuGeom.setCols(cpuGeom.cols);
+	gpuGeom.setVerts(cpuGeom.verts);
+	gpuGeom.setCols(cpuGeom.cols);
 
-	// carConfig.deserialize();
+	carConfig.deserialize();
 
 	// NOTE(beau): put this somewhere else
 	// It's not in the window constructor because input won't
@@ -186,18 +186,16 @@ int main(int argc, char* argv[]) {
 				quit = true;
 		}
 
-		// shader.use();
-		// gpuGeom.bind();
+		shader.use();
+		gpuGeom.bind();
 
 		glEnable(GL_FRAMEBUFFER_SRGB);
 		glClear(GL_COLOR_BUFFER_BIT | GL_DEPTH_BUFFER_BIT);
 
-		//std::cout << GLsizei(cpuGeom.verts.size());
-
-		// for (int i = 0; i < GLsizei(cpuGeom.verts.size()); i+=4)
-		// {
-		// 	glDrawArrays(GL_LINE_LOOP, i, 4);
-		// }
+		for (int i = 0; i < GLsizei(cpuGeom.verts.size()); i+=4)
+		{
+			glDrawArrays(GL_LINE_LOOP, i, 4);
+		}
 
 		glDisable(GL_FRAMEBUFFER_SRGB); // disable sRGB for things like imgui
 

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -22,6 +22,9 @@
 CarPhysics carPhysics;
 CarPhysicsSerde carConfig(carPhysics);
 
+// TODO(beau): decide if we want to use callbacks for input handling, or
+//             or just handle input events in main. If the latter, scrap
+//             all this callback stuff
 // EXAMPLE CALLBACKS
 // class MyCallbacks : public CallbackInterface {
 
@@ -178,15 +181,11 @@ int main(int argc, char* argv[]) {
 	// RENDER LOOP
 	// while (!window.shouldClose()) {
 	bool quit = false;
-	SDL_Event event;
 	while (!quit) {
-		while (SDL_PollEvent(&event)) {
-			if (event.type == SDL_QUIT) {
+		while (SDL_PollEvent(&window.event)) {
+			if (window.event.type == SDL_QUIT)
 				quit = true;
-			}
 		}
-
-		// glfwPollEvents();
 
 		// shader.use();
 		// gpuGeom.bind();
@@ -217,8 +216,7 @@ int main(int argc, char* argv[]) {
 		// ImGui::Render();
 		// ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
-		// window.swapBuffers();
-		SDL_GL_SwapWindow(window.window.get());
+		window.swapBuffers();
 	}
 
 	// ImGui_ImplOpenGL3_Shutdown();

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -107,6 +107,8 @@ int main(int argc, char* argv[]) {
 	SDL_Init(SDL_INIT_EVERYTHING); // initialize all sdl systems
 	Window window(800, 800, "CPSC 453");
 
+	ImGuiIO& io = ImGui::GetIO(); (void)io;
+
 	GLDebug::enable();
 
 	// SHADERS
@@ -181,7 +183,7 @@ int main(int argc, char* argv[]) {
 		ImGui::End();
 
 		ImGui::Render();
-		// TODO(beau): gl viewport thing
+		glViewport(0, 0, (int)io.DisplaySize.x, (int)io.DisplaySize.y);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
 		window.swapBuffers();

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -4,9 +4,7 @@
 #include <iostream>
 
 #include "imgui.h"
-// #include "imgui_impl_glfw.h"
 #include "imgui_impl_sdl.h"
-#include "imgui_impl_sdlrenderer.h"
 #include "imgui_impl_opengl3.h"
 
 #include "Geometry.h"
@@ -136,9 +134,8 @@ std::vector<glm::vec3> colourSquare(std::vector<glm::vec3> dest, glm::vec3 colou
 int main(int argc, char* argv[]) {
 	Log::debug("Starting main");
 
-	// WINDOW
-	SDL_Init(SDL_INIT_EVERYTHING);
-	Window window(800, 800, "CPSC 453"); // can set callbacks at construction if desired
+	SDL_Init(SDL_INIT_EVERYTHING); // initialize all sdl systems
+	Window window(800, 800, "CPSC 453");
 
 	GLDebug::enable();
 
@@ -165,17 +162,6 @@ int main(int argc, char* argv[]) {
 
 	carConfig.deserialize();
 
-	// NOTE(beau): put this somewhere else
-	// It's not in the window constructor because input won't
-	// work unless this code is called after the window callbacks are set
-	// IMGUI_CHECKVERSION();
-	// ImGui::CreateContext();
-	// ImGuiIO& io = ImGui::GetIO(); (void)io;
-
-	// ImGui::StyleColorsDark();
-
-	// ImGui_ImplOpenGL3_Init("#version 330");
-	// ImGui_ImplGlfw_InitForOpenGL(window.window.get(), true);
 
 	// RENDER LOOP
 	// while (!window.shouldClose()) {
@@ -199,26 +185,27 @@ int main(int argc, char* argv[]) {
 
 		glDisable(GL_FRAMEBUFFER_SRGB); // disable sRGB for things like imgui
 
-		// ImGui_ImplOpenGL3_NewFrame();
-		// ImGui_ImplGlfw_NewFrame();
-		// ImGui::NewFrame();
+		ImGui_ImplOpenGL3_NewFrame();
+		ImGui_ImplSDL2_NewFrame();
+		ImGui::NewFrame();
 
-		// ImGui::Begin("Car Physics", nullptr);
+		ImGui::Begin("Car Physics", nullptr);
 
-		// ImGui::SliderFloat("acceleration", &carPhysics.m_acceleration, 0.f, 1000.f);
-		// ImGui::SliderFloat("suspension", &carPhysics.m_suspension_force, 0.f, 1000.f);
+		ImGui::SliderFloat("acceleration", &carPhysics.m_acceleration, 0.f, 1000.f);
+		ImGui::SliderFloat("suspension", &carPhysics.m_suspension_force, 0.f, 1000.f);
 
-		// ImGui::End();
+		ImGui::End();
 
-		// ImGui::Render();
-		// ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
+		ImGui::Render();
+		// TODO(beau): gl viewport thing
+		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());
 
 		window.swapBuffers();
 	}
 
-	// ImGui_ImplOpenGL3_Shutdown();
-	// ImGui_ImplGlfw_Shutdown();
-	// ImGui::DestroyContext();
+	ImGui_ImplOpenGL3_Shutdown();
+	ImGui_ImplSDL2_Shutdown();
+	ImGui::DestroyContext();
 
 	SDL_Quit();
 	return 0;

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -168,8 +168,26 @@ int main(int argc, char* argv[]) {
 	bool quit = false;
 	while (!quit) {
 		while (SDL_PollEvent(&window.event)) {
+			ImGui_ImplSDL2_ProcessEvent(&window.event);
+
 			if (window.event.type == SDL_QUIT)
 				quit = true;
+
+			if (window.event.type == SDL_KEYDOWN) {
+				switch (window.event.key.keysym.sym) {
+					case SDLK_r:
+						shader.recompile();
+						break;
+					case SDLK_t:
+						carConfig.deserialize();
+						break;
+					case SDLK_s:
+						carConfig.serialize();
+						break;
+					default:
+						break;
+				};
+			}
 		}
 
 		shader.use();

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -1,5 +1,4 @@
 #include <GL/glew.h>
-// #include <GLFW/glfw3.h>
 
 
 #include <iostream>
@@ -224,6 +223,5 @@ int main(int argc, char* argv[]) {
 	// ImGui::DestroyContext();
 
 	SDL_Quit();
-	// glfwTerminate();
 	return 0;
 }

--- a/code/vcpkg.json
+++ b/code/vcpkg.json
@@ -7,7 +7,6 @@
     "glm",
     "glew",
     "assimp",
-    "glfw3",
     "tomlplusplus",
     {
       "name": "imgui",

--- a/code/vcpkg.json
+++ b/code/vcpkg.json
@@ -13,7 +13,8 @@
       "name": "imgui",
       "features": [
         "opengl3-binding",
-        "glfw-binding"
+        "sdl2-binding",
+        "sdl2-renderer-binding"
       ]
     }
   ]


### PR DESCRIPTION
Migrate from GLFW to SDL2. This has a number of benefits:

- SDL2 provides everything glfw does, along with several additional useful features (see https://wiki.libsdl.org/SDL2/Introduction)
    - threading api, actually good timer, etc
- the api is considerably more straightforward and simple to use
    - e.g. no callbacks
- got to clean out a lot of code including callback code. Windowing and input handling look so much better!
- easy vsync
- etc.

Insert obligatory "test on your machines so I can fix and then merge" here. Leave a review to lmk if everything worked or if there was as problem.