### PR TITLE
Fix: ecs can be included anywhere

### DIFF
--- a/code/lib/systems/ecs.cpp
+++ b/code/lib/systems/ecs.cpp
@@ -1,0 +1,8 @@
+#include "ecs.h"
+
+namespace ecs {
+    ComponentFlags componentMaskFromGuid(Guid componentGuid)
+    {
+        return (static_cast<u64>(1) << componentGuid);
+    }
+}

--- a/code/lib/systems/ecs.h
+++ b/code/lib/systems/ecs.h
@@ -1,3 +1,4 @@
+// TODO(beau): put definitions in ecs.cpp and have this file just be declarations
 #pragma once
 
 #include <string>

--- a/code/lib/systems/ecs.h
+++ b/code/lib/systems/ecs.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <string>
 #include "int_types.h"
 #include <vector>
 #include <array>

--- a/code/lib/systems/ecs.h
+++ b/code/lib/systems/ecs.h
@@ -36,10 +36,7 @@ namespace ecs
     /// @brief Gets the mask for the component by shifting according to the provided GUID.
     /// @param componentGuid
     /// @return ComponentFlags with only this component enabled
-    ComponentFlags componentMaskFromGuid(Guid componentGuid)
-    {
-        return (static_cast<u64>(1) << componentGuid);
-    }
+    ComponentFlags componentMaskFromGuid(Guid componentGuid);
 
     namespace memory
     {


### PR DESCRIPTION
Ecs didn't include string but depended on it before which meant that it would only work in a given file if stuff from std::string got put there first. Additionally, a procedure was defined in the header file which caused some duplicate definition link errors. I've fixed both of these and you should now be able to include `ecs.h` anywhere without including anything else.