### PR TITLE
Added an imgui window to switch camera modes

### DIFF
--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -394,6 +394,8 @@ int main(int argc, char* argv[]) {
 		// NOTE: the imgui bible - beau
 		//ImGui::ShowDemoWindow();
 
+		gs.ImGuiPanel();
+
 		ImGui::Render();
 		glViewport(0, 0, (int)io.DisplaySize.x, (int)io.DisplaySize.y);
 		ImGui_ImplOpenGL3_RenderDrawData(ImGui::GetDrawData());

--- a/code/lib/systems/GraphicsSystem.cpp
+++ b/code/lib/systems/GraphicsSystem.cpp
@@ -36,6 +36,20 @@ GraphicsSystem::GraphicsSystem(Window& _window) :
 	colorUniform = glGetUniformLocation(GLuint(shader), "userColor");
 }
 
+// Panel to controls the cameras
+void GraphicsSystem::ImGuiPanel() {
+	ImGui::Begin("Camera States");
+
+	if (ImGui::Button("Free Camera")) {
+		cam_mode = 1;
+	}
+	if (ImGui::Button("Fixed Camera")) {
+		cam_mode = 2;
+	}
+
+	ImGui::End();
+}
+
 void GraphicsSystem::Update(ecs::Scene& scene, float deltaTime) {
 	glEnable(GL_LINE_SMOOTH);
 	glEnable(GL_FRAMEBUFFER_SRGB);
@@ -52,12 +66,22 @@ void GraphicsSystem::Update(ecs::Scene& scene, float deltaTime) {
 		//glm::mat4 V = cameras[i].getView();
 		// Hardcoded camera value, it can't move after this 
 		
-		glm::mat4 V = { 0.658686, -0.565264, 0.496598, 0,
-						0, 0.660003, 0.751263, 0,
-						-0.752418, -0.494847, 0.434735, 0,
-						9.27202, -0.914308, -33.4781, 1
-		};
-		
+		// If camera mode is 1 - use freecam
+		if (cam_mode == 1) {
+			V = cameras[i].getView();
+		}
+		// If cam mode is 2 - use fixed camera (values from milestone 2)
+		else if (cam_mode == 2) {
+			V = { 0.658686, -0.565264, 0.496598, 0,
+				0, 0.660003, 0.751263, 0,
+				-0.752418, -0.494847, 0.434735, 0,
+				9.27202, -0.914308, -33.4781, 1
+			};
+		}
+		// TODO: Follow camera mode
+		else {
+			V = cameras[i].getView();
+		}
 
 		glUniformMatrix4fv(perspectiveUniform, 1, GL_FALSE, glm::value_ptr(P));
 		glUniformMatrix4fv(viewUniform, 1, GL_FALSE, glm::value_ptr(V));

--- a/code/lib/systems/GraphicsSystem.h
+++ b/code/lib/systems/GraphicsSystem.h
@@ -22,6 +22,7 @@
 struct GraphicsSystem : ecs::ISystem {
 public:
 	GraphicsSystem(Window& _window);
+	void GraphicsSystem::ImGuiPanel();
 	void Update(ecs::Scene& scene, float deltaTime);
 	void input(SDL_Event&, int _cameraID);
 	glm::mat4 getCameraView();
@@ -30,6 +31,7 @@ private:
 	Camera cameras[4];
 	//uniforms
 	int numCamerasActive = 1;
+	int cam_mode = 1; // Used to determine what mode the camera should use (free, fixed, follow)
 	GLint modelUniform = -1;
 	GLuint viewUniform = -1;
 	GLuint perspectiveUniform = -1;
@@ -41,6 +43,7 @@ private:
 	GLuint ambiantStrengthUniform = -1;
 	GLuint specularStrengthUniform = -1;
 	GLuint colorUniform = -1;
+	glm::mat4 V = glm::mat4(1.f); // Had to declare this variable here for the rest of the program to work
 
 	ShaderProgram shader;
 	glm::ivec2 windowSize;


### PR DESCRIPTION
The imgui panel is in graphic system.cpp
Clicking the buttons switches an int value.

This int value is used in the update function and depending on the int value it uses different V values which correspond to different camera modes (Free, fixed) - can be extended to toggle follow camera.

I had to put the cam_mode int into the GraphicSystem header file, and initialize the V glm::mat4 in the header file for this to work.

I then call gs.ImGuiPanel in main for the panel to show up and the changes when the buttons are pressed to propagate properly