### PR TITLE
Tire tracks skid only

### DIFF
--- a/code/client/ImGuiTuneables.cpp
+++ b/code/client/ImGuiTuneables.cpp
@@ -151,7 +151,6 @@ void dampeningRatioPrint(int i) {
 }
 
 void vehicleTuning(EngineDriveVehicle &m_Vehicle, physics::PhysicsSystem &m_Physics) {
-	ImGui::Begin("Vehicle Tuning");
 
 	// PhysX material 
 	// TODO : (right now affects all objects, will need to assign different materials to different objects)
@@ -603,11 +602,9 @@ void vehicleTuning(EngineDriveVehicle &m_Vehicle, physics::PhysicsSystem &m_Phys
 		ImGui::TreePop();
 	}
 
-	ImGui::End();
 }
 
 void engineTuning(EngineDriveVehicle &m_Vehicle) {
-	ImGui::Begin("Engine Tuning");
 
 	if (ImGui::TreeNode("Engine Params:")) {
 
@@ -813,8 +810,6 @@ void engineTuning(EngineDriveVehicle &m_Vehicle) {
 	}
 
 	
-
-	ImGui::End();
 }
 
 void reloadVehicleJSON(EngineDriveVehicle &m_Vehicle) {

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -722,10 +722,11 @@ int main(int argc, char* argv[]) {
 					gs.ImGuiPanel();
 					ImGui::EndTabItem();
 				}
-				if (ImGui::BeginTabItem("Obstacles")) {
+				if (ImGui::BeginTabItem("Misc")) {
 					// Obstacles ImGui
 					obstaclesImGui(mainScene, physicsSystem);
 					ImGui::Checkbox("Nav Path Render", &navPathToggle);
+					tireTrackImgui();
 					ImGui::EndTabItem();
 				}
 				ImGui::EndTabBar();

--- a/code/client/entities/car/Car.cpp
+++ b/code/client/entities/car/Car.cpp
@@ -156,7 +156,7 @@ PxRigidBody* Car::getVehicleRigidBody()
 }
 
 void Car::carImGui() {
-    ImGui::Begin("Car");
+    //ImGui::Begin("Car");
     if (ImGui::TreeNode("Debug Readouts")) {        
         ImGui::Text("left stick horizontal tilt: %f", carAxis);
         //ImGui::Text("Car Throttle: %f", controller_throttle);
@@ -177,6 +177,9 @@ void Car::carImGui() {
         ImGui::Text("Steer Response: %f", m_Vehicle.mBaseParams.steerResponseParams.maxResponse);
         ImGui::Text("Linear Velocity: %f, %f, %f", m_Vehicle.mPhysXState.physxActor.rigidBody->getLinearVelocity().x, m_Vehicle.mPhysXState.physxActor.rigidBody->getLinearVelocity().y,
             m_Vehicle.mPhysXState.physxActor.rigidBody->getLinearVelocity().z);
+        auto vehicleRot = m_Vehicle.mPhysXState.physxActor.rigidBody->getGlobalPose().q;
+        ImGui::Text("Car rotation: %f, %f, %f, %f", vehicleRot.w, vehicleRot.x, vehicleRot.y, vehicleRot.z);
+        ImGui::Text("Friction? %f, %f", m_Vehicle.mBaseState.tireSlipStates->slips[0], m_Vehicle.mBaseState.tireSlipStates->slips[1]);
         ImGui::TreePop();
     }
     if (ImGui::TreeNode("Parameter Switching")) {
@@ -190,7 +193,7 @@ void Car::carImGui() {
         ImGui::TreePop();
     }
 
-    ImGui::End();
+    //ImGui::End();
 }
 
 void Car::baseSetup() {

--- a/code/client/entities/car/TireTracks.cpp
+++ b/code/client/entities/car/TireTracks.cpp
@@ -2,6 +2,10 @@
 #include "AICar.h"
 #include <iostream>
 
+#include "imgui.h"
+#include "imgui_impl_sdl.h"
+#include "imgui_impl_opengl3.h"
+
 /*
 * put them in a struct for easier code readability and easier expandability for future effects
 */
@@ -13,6 +17,15 @@ struct attachedVFX {
 
 std::vector<std::array<bool, 3>> previousStates;
 std::vector<attachedVFX> VFXGuids;
+
+// Set this value for how much slip must happen for the tire tracks to render
+// lower happens more frequently
+float maxSlip = 0.6f;
+
+void tireTrackImgui() {
+	ImGui::Text("Value for how much the car needs to slip for the tire tracks to render");
+	ImGui::InputFloat("Max Slip Threshold: %f", &maxSlip);
+}
 
 // Sets up tire tracks ecs entities
 // Needs a unique one for each driver
@@ -117,8 +130,6 @@ void updateCarVFX(ecs::Scene mainScene, float dt) {
 		TransformComponent& frontTireTransform = mainScene.GetComponent<TransformComponent>(vfx.trackGuids[0]);
 		TransformComponent& rightTireTransform = mainScene.GetComponent<TransformComponent>(vfx.trackGuids[1]);
 		TransformComponent& leftTireTransform = mainScene.GetComponent<TransformComponent>(vfx.trackGuids[2]);
-
-		float maxSlip = 0.6f;
 		
 		if (car->m_Vehicle.mBaseState.roadGeomStates[0].hitState && car->m_Vehicle.mBaseState.roadGeomStates[1].hitState
 			&& (car->m_Vehicle.mBaseState.tireSlipStates->slips[1] > maxSlip || car->m_Vehicle.mBaseState.tireSlipStates->slips[1] < -maxSlip)) {

--- a/code/client/entities/car/TireTracks.cpp
+++ b/code/client/entities/car/TireTracks.cpp
@@ -118,7 +118,10 @@ void updateCarVFX(ecs::Scene mainScene, float dt) {
 		TransformComponent& rightTireTransform = mainScene.GetComponent<TransformComponent>(vfx.trackGuids[1]);
 		TransformComponent& leftTireTransform = mainScene.GetComponent<TransformComponent>(vfx.trackGuids[2]);
 
-		if (car->m_Vehicle.mBaseState.roadGeomStates[0].hitState && car->m_Vehicle.mBaseState.roadGeomStates[1].hitState) {
+		float maxSlip = 0.6f;
+		
+		if (car->m_Vehicle.mBaseState.roadGeomStates[0].hitState && car->m_Vehicle.mBaseState.roadGeomStates[1].hitState
+			&& (car->m_Vehicle.mBaseState.tireSlipStates->slips[1] > maxSlip || car->m_Vehicle.mBaseState.tireSlipStates->slips[1] < -maxSlip)) {
 			previousStates.at(i).at(0) = true;
 			glm::vec3 frontTirePosition = frontTireTransform.getTransformationMatrix() * glm::vec4(0, y_offset, 0, 1);
 			if (glm::length(frontTirePosition - frontTireTracks.g_previousPosition()) > 1) {
@@ -135,7 +138,7 @@ void updateCarVFX(ecs::Scene mainScene, float dt) {
 		}
 
 		//right tire
-		if (car->m_Vehicle.mBaseState.roadGeomStates[2].hitState) {
+		if (car->m_Vehicle.mBaseState.roadGeomStates[2].hitState && (car->m_Vehicle.mBaseState.tireSlipStates->slips[1] > maxSlip || car->m_Vehicle.mBaseState.tireSlipStates->slips[1] < -maxSlip)) {
 			previousStates.at(i).at(1) = true;
 			glm::vec3 rightTirePosition = rightTireTransform.getTransformationMatrix() * glm::vec4(0, y_offset, 0, 1);
 			if (glm::length(rightTirePosition - rightTireTracks.g_previousPosition()) > 1) {
@@ -152,7 +155,7 @@ void updateCarVFX(ecs::Scene mainScene, float dt) {
 		}
 
 		//left tire
-		if (car->m_Vehicle.mBaseState.roadGeomStates[3].hitState) {
+		if (car->m_Vehicle.mBaseState.roadGeomStates[3].hitState && (car->m_Vehicle.mBaseState.tireSlipStates->slips[1] > maxSlip || car->m_Vehicle.mBaseState.tireSlipStates->slips[1] < -maxSlip)) {
 			previousStates.at(i).at(2) = true;
 			glm::vec3 leftTirePosition = leftTireTransform.getTransformationMatrix() * glm::vec4(0, y_offset, 0, 1);
 			if (glm::length(leftTirePosition - leftTireTracks.g_previousPosition()) > 1) {
@@ -190,17 +193,17 @@ void updateCarVFX(ecs::Scene mainScene, float dt) {
 		VFXParticleSystem& rightTireParticle = mainScene.GetComponent<VFXParticleSystem>(vfx.trackGuids[1]);
 		VFXParticleSystem& leftTireParticle = mainScene.GetComponent<VFXParticleSystem>(vfx.trackGuids[2]);
 
-		if (!previousStates[i][0])
+		if (!car->m_Vehicle.mBaseState.roadGeomStates[0].hitState && car->m_Vehicle.mBaseState.roadGeomStates[1].hitState)
 			frontTireParticle.active = false;
 		else
 			frontTireParticle.active = true;
 
-		if (!previousStates[i][1])
+		if (!car->m_Vehicle.mBaseState.roadGeomStates[2].hitState)
 			rightTireParticle.active = false;
 		else
 			rightTireParticle.active = true;
 
-		if (!previousStates[i][2])
+		if (!car->m_Vehicle.mBaseState.roadGeomStates[3].hitState)
 			leftTireParticle.active = false;
 		else
 			leftTireParticle.active = true;

--- a/code/client/entities/car/TireTracks.h
+++ b/code/client/entities/car/TireTracks.h
@@ -7,3 +7,4 @@
 void setupCarVFX(ecs::Scene& mainScene, Guid _ID);
 void updateCarVFX(ecs::Scene mainScene, float _dt);
 
+void tireTrackImgui();

--- a/code/client/entities/physics/Obstacles.cpp
+++ b/code/client/entities/physics/Obstacles.cpp
@@ -498,8 +498,6 @@ void setUpLogs(ecs::Scene &mainScene) {
 }
 
 void obstaclesImGui(ecs::Scene& mainScene, physics::PhysicsSystem physicsSystem) {
-	ImGui::Begin("Obstacles");
-
 	if (ImGui::Checkbox("Obstacles", &obstaclesOn)) {
 		if (obstaclesOn) {
 			//setUpLogs(mainScene);
@@ -510,6 +508,4 @@ void obstaclesImGui(ecs::Scene& mainScene, physics::PhysicsSystem physicsSystem)
 			clearObstacles(physicsSystem, mainScene);
 		}
 	}
-
-	ImGui::End();
 }


### PR DESCRIPTION
I wanted to make the tire tracks only show up when the car is skidding. 

This PR includes new checks for the tire tracks, based on a maxSlip coefficient. 
This variable can be set in an ImGui window for testing. The current setting is 0.6 which makes the tire tracks only happen when you are skidding around a corner hard.

Lower values will make them appear more frequently, I find anything below 0.6 makes them appear in normal turns, I liked 0.6 better