### PR TITLE
Controller Pause & Reset

### DIFF
--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -596,13 +596,13 @@ int main(int argc, char* argv[]) {
 		for (int i = 0; i < number_players; i++)
 		{
 			Car& testCar = mainScene.GetComponent<Car>(AIGuids[i]);
-			if (testCar.carControllerStartPressed()) {
+			if (testCar.carGetControllerStartPressed()) {
 				if (gamePaused) { gamePaused = false; }
-				else if (!gamePaused) { gamePaused = true;  }
+				else if (!gamePaused) { gamePaused = true;  }				
 			}
 			
-			if (testCar.carControllerSelectPressed()) {
-				resetLevel(testCar, AIGuids, mainScene, spawnPoints, raceSystem, acc_t, forward);
+			if (testCar.carGetControllerSelectPressed()) {
+				resetLevel(testCar, AIGuids, mainScene, spawnPoints, raceSystem, acc_t, forward);				
 			}
 		}
 

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -554,6 +554,7 @@ int main(int argc, char* argv[]) {
 						else {
 							gamePaused = true;
 						}
+						break;
 					case SDLK_p:
 						if (!showImgui) {
 							showImgui = true;

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -288,7 +288,6 @@ int main(int argc, char* argv[]) {
 		gs.bindCameraToEntity(i, AIGuids[i]);
 	}
 
-
 	// bandaids for other calls that do player-only stuff
 	Car& testCar = mainScene.GetComponent<Car>(AIGuids[0]);
 	Guid carGuid = AIGuids[0];
@@ -590,6 +589,23 @@ int main(int argc, char* argv[]) {
 			//pass the event to the camera
 			gs.input(windowEvent, 0);
 		}
+
+		// Iterates through all player controllers and
+		// checks if the start or select button has been pressed
+		// and launches the approriate functions 
+		for (int i = 0; i < number_players; i++)
+		{
+			Car& testCar = mainScene.GetComponent<Car>(AIGuids[i]);
+			if (testCar.carControllerStartPressed()) {
+				if (gamePaused) { gamePaused = false; }
+				else if (!gamePaused) { gamePaused = true;  }
+			}
+			
+			if (testCar.carControllerSelectPressed()) {
+				resetLevel(testCar, AIGuids, mainScene, spawnPoints, raceSystem, acc_t, forward);
+			}
+		}
+
 
 		// Check for the car grounded state, and if grounded after being in the air
 		// resets the modifications made to the car while in the air

--- a/code/client/client.cpp
+++ b/code/client/client.cpp
@@ -468,6 +468,18 @@ int main(int argc, char* argv[]) {
     SoundUpdater soundUpdater;
     soundUpdater.Initialize(mainScene);
 
+	// button press frame data for the controller start buttons
+	// used to prevent holding down behaviour triggering multiple
+	// commands in a row
+	bool start_button_previous_frame[4];
+	for (int i = 0; i < 4; i++) {
+		start_button_previous_frame[i] = false;
+	}
+	bool start_button_current_frame[4];
+	for (int i = 0; i < 4; i++) {
+		start_button_current_frame[i] = false;
+	}
+
 		std::cout << "initalization finished, beginning game\n";
 
 	// GAME LOOP
@@ -596,14 +608,25 @@ int main(int argc, char* argv[]) {
 		for (int i = 0; i < number_players; i++)
 		{
 			Car& testCar = mainScene.GetComponent<Car>(AIGuids[i]);
-			if (testCar.carGetControllerStartPressed()) {
+
+			// Checks the controller input and saves the value for the current frame
+			start_button_current_frame[i] = testCar.carGetControllerStartPressed();
+
+			// Checks if the current frame had no button press, and the current frame had a button press
+			// This is to prevent "holding down button" behaviour triggering the game to be paused on and off
+			// repeatiedly 
+			if (start_button_current_frame[i] && !start_button_previous_frame[i]) {
+
 				if (gamePaused) { gamePaused = false; }
-				else if (!gamePaused) { gamePaused = true;  }				
+				else if (!gamePaused) { gamePaused = true; }
 			}
 			
 			if (testCar.carGetControllerSelectPressed()) {
 				resetLevel(testCar, AIGuids, mainScene, spawnPoints, raceSystem, acc_t, forward);				
 			}
+
+			// Saves the current frame data as the previous frame for the next frame go around
+			start_button_previous_frame[i] = start_button_current_frame[i];
 		}
 
 

--- a/code/client/entities/car/Car.cpp
+++ b/code/client/entities/car/Car.cpp
@@ -21,6 +21,9 @@ float carAxisScale = 1.f;
 float controller_throttle = 0.f;
 float controller_brake = 0.f;
 
+bool start_pressed = false;
+bool select_pressed = false;
+
 int time_elapsed = 0;
 bool has_jumped = false;
 bool previous_b_press = false;
@@ -483,6 +486,24 @@ Command Car::drive(ecs::Scene& scene, float deltaTime)
         auto m_key = keys_arr[SDL_SCANCODE_M];
         auto f_key = keys_arr[SDL_SCANCODE_F];
 
+
+        // The two if statements below are used in the render loop to check if any of the 
+        // controllers have pressed these buttons, and then resets the booleans 
+        // 
+        // This checks if the start button has been pressed, and sets the boolean for that
+        // button to true if not true
+        if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_START)) {
+            if (!start_pressed) { start_pressed = true; }
+        }
+
+        // This checks if the start button has been pressed, and sets the boolean for that
+        // button to true if not true
+        if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_BACK)) {
+            if (!select_pressed) { select_pressed = true; }
+        }
+        //
+        //
+
         // Jump
         // Checks if the previous frame was a jump, so that it does not cumulatively add impulse
         if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_A) && this->m_Vehicle.mBaseState.roadGeomStates->hitState)
@@ -839,3 +860,27 @@ Command Car::pathfind(ecs::Scene& scene, float deltaTime)
     return command;
 }
 
+// The two functions below are return functions,
+// they are kind of hacky and jank, but it's because I could not put
+// a controller polling in the main loop as there is potentially up to 4
+// different controllers active and we need to read input from any one of them
+// This way each controller is attached to a player / car
+
+// Function that will be called every frame
+// Checks if the start button has been pressed
+// if true, reset the start button boolean, and return true
+bool Car::carControllerStartPressed() {
+    if (start_pressed) {
+        start_pressed = false;
+        return true;
+    }
+}
+// Function that will be called every frame
+// Checks if the select button has been pressed
+// if true, reset the select button boolean, and return true
+bool Car::carControllerSelectPressed() {
+    if (select_pressed) {
+        select_pressed = false;
+        return true;
+    }
+}

--- a/code/client/entities/car/Car.cpp
+++ b/code/client/entities/car/Car.cpp
@@ -486,24 +486,6 @@ Command Car::drive(ecs::Scene& scene, float deltaTime)
         auto m_key = keys_arr[SDL_SCANCODE_M];
         auto f_key = keys_arr[SDL_SCANCODE_F];
 
-
-        // The two if statements below are used in the render loop to check if any of the 
-        // controllers have pressed these buttons, and then resets the booleans 
-        // 
-        // This checks if the start button has been pressed, and sets the boolean for that
-        // button to true if not true
-        if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_START)) {
-            if (!start_pressed) { start_pressed = true; }
-        }
-
-        // This checks if the start button has been pressed, and sets the boolean for that
-        // button to true if not true
-        if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_BACK)) {
-            if (!select_pressed) { select_pressed = true; }
-        }
-        //
-        //
-
         // Jump
         // Checks if the previous frame was a jump, so that it does not cumulatively add impulse
         if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_A) && this->m_Vehicle.mBaseState.roadGeomStates->hitState)
@@ -860,27 +842,39 @@ Command Car::pathfind(ecs::Scene& scene, float deltaTime)
     return command;
 }
 
-// The two functions below are return functions,
-// they are kind of hacky and jank, but it's because I could not put
-// a controller polling in the main loop as there is potentially up to 4
-// different controllers active and we need to read input from any one of them
-// This way each controller is attached to a player / car
 
-// Function that will be called every frame
-// Checks if the start button has been pressed
-// if true, reset the start button boolean, and return true
-bool Car::carControllerStartPressed() {
-    if (start_pressed) {
-        start_pressed = false;
+// Two functions below are not in an update loop because 
+// they pause and reset the game, when the game is paused the update
+// loop no longer gets called so you could not unpause the game
+
+bool Car::carGetControllerStartPressed() {
+    SDL_GameController* controller{ nullptr };
+    // get controller if it exists
+    if (controllerIndex != -1)
+    {
+        // controller exists for player
+        controller = ControllerInput::controllers[controllerIndex];
+    }
+
+    if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_START)) {
         return true;
     }
+
+    return false;
 }
-// Function that will be called every frame
-// Checks if the select button has been pressed
-// if true, reset the select button boolean, and return true
-bool Car::carControllerSelectPressed() {
-    if (select_pressed) {
-        select_pressed = false;
+
+bool Car::carGetControllerSelectPressed() {
+    SDL_GameController* controller{ nullptr };
+    // get controller if it exists
+    if (controllerIndex != -1)
+    {
+        // controller exists for player
+        controller = ControllerInput::controllers[controllerIndex];
+    }
+
+    if (SDL_GameControllerGetButton(controller, SDL_CONTROLLER_BUTTON_BACK)) {
         return true;
     }
+
+    return false;
 }

--- a/code/client/entities/car/Car.h
+++ b/code/client/entities/car/Car.h
@@ -103,8 +103,8 @@ struct Car {
     void baseSetup();
     void setup1();
 
-    bool carControllerStartPressed();
-    bool carControllerSelectPressed();
+    bool carGetControllerStartPressed();
+    bool carGetControllerSelectPressed();
 
     // movement 
     Command drive(ecs::Scene& scene, float deltaTime);

--- a/code/client/entities/car/Car.h
+++ b/code/client/entities/car/Car.h
@@ -24,7 +24,6 @@ extern float carBrake;
 extern float carAxis;
 extern float carAxisScale;
 
-
 // Commands are issued to the vehicle in a pre-choreographed sequence.
 struct Command
 {
@@ -103,6 +102,9 @@ struct Car {
     void cleanupVehicle();
     void baseSetup();
     void setup1();
+
+    bool carControllerStartPressed();
+    bool carControllerSelectPressed();
 
     // movement 
     Command drive(ecs::Scene& scene, float deltaTime);


### PR DESCRIPTION
Implemented the ability to pause and reset with the controller start and select (back / options) button. 

start pauses, select resets the game. 


It's a bit messy as I had to put the controller code in the car.cpp as each car has its own controller, so in the render loop I had to iterate over all the player cars and check their controller inputs. 
These controller inputs are not tied to the physics updates as when the game is paused the physics updates are paused too, so putting the controller input inside the physics update function would make it so when the game was paused via controller you could no longer pause it. 

Another issue arose which was that holding down the start button would continuously pause and unpause the game. I had to create a state buffer that recorded the current state of the controller, and only pause the game if the previous frame had no start button press and the current frame did.